### PR TITLE
Setup Hrev Dev agency monorepo with docs

### DIFF
--- a/docs/app/[[...slug]]/(home)/components/footer.tsx
+++ b/docs/app/[[...slug]]/(home)/components/footer.tsx
@@ -2,25 +2,16 @@ export const Footer = () => (
   <div className="bg-dashed">
     <div className="container mx-auto flex items-center justify-between p-8 text-muted-foreground">
       <p className="mx-auto block text-center text-sm">
-        Built with love by{' '}
+        © {new Date().getFullYear()} Hrev Dev. Crafted with Next.js, Turborepo and shadcn/ui.{' '}
         <a
-          href="https://x.com/haydenbleasel"
+          href="https://github.com/hrev-dev/agency"
           target="_blank"
           rel="noopener noreferrer"
           className="text-foreground underline"
         >
-          Hayden Bleasel
+          View source
         </a>
-        . Maintained by a brilliant community of{' '}
-        <a
-          href="https://github.com/vercel/next-forge"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-foreground underline"
-        >
-          developers
-        </a>
-        .
+        . All rights reserved.
       </p>
     </div>
   </div>

--- a/docs/app/[[...slug]]/(home)/components/hero.tsx
+++ b/docs/app/[[...slug]]/(home)/components/hero.tsx
@@ -51,33 +51,27 @@ const TurborepoLogo = (props: ComponentProps<'svg'>) => (
 export const Hero = () => (
   <section className="flex flex-col items-center justify-center gap-6 bg-dashed px-4 py-16 sm:px-16 sm:py-24">
     <a
-      href="https://x.com/haydenbleasel/status/1929625673586598148"
-      target="_blank"
+      href="/docs/ui-showcase"
       className="inline-flex overflow-hidden w-full sm:w-fit items-center gap-2 rounded-full border bg-background py-1 pr-3 pl-1 text-foreground text-sm leading-6 shadow-xs"
       rel="noreferrer"
     >
-      <span className="rounded-full bg-secondary px-2 font-semibold">
-        Update
-      </span>
-      <span className="font-medium truncate">
-        next-forge has been acquired by Vercel
-      </span>
+      <span className="rounded-full bg-secondary px-2 font-semibold">New</span>
+      <span className="font-medium truncate">Introducing Hrev UI — our shadcn/ui component library</span>
     </a>
     <h1 className="max-w-3xl text-balance text-center font-semibold text-4xl leading-tight tracking-tighter! sm:text-5xl md:max-w-4xl md:text-6xl lg:leading-[1.1]">
-      Production-grade{' '}
+      Hrev Dev — Expert{' '}
       <TurborepoLogo className="pointer-events-none mx-1.5 inline-block h-8 w-auto translate-y-0.5 select-none align-baseline sm:h-[38px] md:h-[48px] md:translate-y-1" />
-      Turborepo template for{' '}
+      Turborepo &{' '}
       <NextLogo className="pointer-events-none mx-1.5 inline-block h-8 w-auto translate-y-0.5 select-none align-baseline sm:h-[38px] md:h-[48px] md:translate-y-1 dark:invert" />
-      Next.js apps
+      Next.js agency
     </h1>
     <p className="max-w-xl text-balance text-center text-muted-foreground md:max-w-2xl md:text-lg">
-      A monorepo template designed to have everything you need to build your new
-      SaaS app as thoroughly as possible. Free and open source, forever.
+      We design, build, and scale modern web apps. Monorepo-first architecture, performance-driven UI, and production-grade DX.
     </p>
     <div className="mx-auto flex w-full max-w-lg flex-col items-center gap-4 sm:flex-row">
       <Installer />
       <Button asChild size="lg">
-        <Link href="/docs">Read the docs</Link>
+        <Link href="/docs">Explore our docs</Link>
       </Button>
     </div>
   </section>

--- a/docs/app/[[...slug]]/page.tsx
+++ b/docs/app/[[...slug]]/page.tsx
@@ -106,9 +106,9 @@ export async function generateMetadata(props: {
 
   if (!params.slug) {
     return {
-      title: 'Production-grade Turborepo template for Next.js apps',
+      title: 'Hrev Dev — Web development agency',
       description:
-        "A monorepo template designed to have everything you need to build your new SaaS app as quick as possible. Authentication, billing, analytics, SEO, database ORM and more — it's all here.",
+        'We build modern Next.js apps with a rock-solid Turborepo monorepo, battle-tested UI, and pro templates ready to ship.',
     };
   }
 

--- a/docs/app/layout.config.tsx
+++ b/docs/app/layout.config.tsx
@@ -32,7 +32,7 @@ const Slash = () => (
 );
 
 export const baseOptions: BaseLayoutProps = {
-  githubUrl: 'https://github.com/vercel/next-forge',
+  githubUrl: 'https://github.com/hrev-dev/agency',
   links: [
     {
       text: 'Home',
@@ -48,7 +48,7 @@ export const baseOptions: BaseLayoutProps = {
       <div className="flex items-center gap-2">
         <Vercel />
         <Slash />
-        <p className="font-semibold text-lg tracking-tight">next-forge</p>
+        <p className="font-semibold text-lg tracking-tight">Hrev Dev</p>
       </div>
     ),
   },

--- a/docs/biome.jsonc
+++ b/docs/biome.jsonc
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.2.0/schema.json",
+  "extends": ["ultracite"]
+}

--- a/docs/content/docs/docs/meta.json
+++ b/docs/content/docs/docs/meta.json
@@ -4,6 +4,8 @@
   "pages": [
     "---Introduction---",
     "index",
+    "ui-showcase",
+    "pro-templates",
     "philosophy",
     "structure",
     "updates",

--- a/docs/content/docs/docs/meta.json
+++ b/docs/content/docs/docs/meta.json
@@ -6,6 +6,7 @@
     "index",
     "ui-showcase",
     "pro-templates",
+    "pricing",
     "philosophy",
     "structure",
     "updates",

--- a/docs/content/docs/docs/pricing.mdx
+++ b/docs/content/docs/docs/pricing.mdx
@@ -1,0 +1,22 @@
+---
+title: Pricing
+description: Transparent pricing for Hrev Dev services and Pro Templates.
+---
+
+## Services
+
+- Discovery & Architecture: from $2,500
+- Design System Setup (Hrev UI): from $3,500
+- Web Marketing Site: from $6,500
+- SaaS App Shell (auth, billing, dashboard): from $9,500
+
+All projects include performance budgets, accessibility checks, and CI.
+
+## Pro Templates
+
+- Marketing Starter: $199
+- Dashboard Starter: $299
+- SaaS Shell: $399
+
+Team licenses and studio bundles available on request.
+

--- a/docs/content/docs/docs/pro-templates.mdx
+++ b/docs/content/docs/docs/pro-templates.mdx
@@ -1,0 +1,24 @@
+---
+title: Pro Templates
+description: Production-ready templates for dashboards, SaaS marketing, and apps.
+---
+
+Our Pro Templates accelerate delivery with polished UX, responsive layouts, and sensible data wiring. They’re built on the same stack we use for client projects.
+
+## What’s included
+
+- Auth-ready pages (Clerk-ready placeholders)
+- App Shell with sidebar, header, user menu
+- Dashboard widgets: charts, tables, metrics
+- Marketing landing with pricing, FAQ, blog-ready
+- Email templates (React Email)
+- Dark mode, i18n-ready wiring
+
+## Live previews
+
+Previews will be available directly inside this docs as interactive playgrounds. For now, contact us to request access.
+
+## Licensing
+
+Commercial use permitted. One license per project. Reach out for studio or unlimited plans.
+

--- a/docs/content/docs/docs/ui-showcase.mdx
+++ b/docs/content/docs/docs/ui-showcase.mdx
@@ -5,9 +5,7 @@ description: Explore Hrev UI — our curated shadcn/ui components with sensible 
 
 Welcome to Hrev UI. Below are a few of the components we ship and use across projects.
 
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, Tabs, TabsContent, TabsList, TabsTrigger } from '@repo/hrev-ui'
 import { Input } from '@/components/ui/input'
 
 ## Buttons

--- a/docs/content/docs/docs/ui-showcase.mdx
+++ b/docs/content/docs/docs/ui-showcase.mdx
@@ -1,0 +1,75 @@
+---
+title: UI Showcase
+description: Explore Hrev UI — our curated shadcn/ui components with sensible defaults.
+---
+
+Welcome to Hrev UI. Below are a few of the components we ship and use across projects.
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Input } from '@/components/ui/input'
+
+## Buttons
+
+<div className="flex gap-3 flex-wrap">
+  <Button>Primary</Button>
+  <Button variant="secondary">Secondary</Button>
+  <Button variant="outline">Outline</Button>
+  <Button variant="ghost">Ghost</Button>
+  <Button variant="destructive">Destructive</Button>
+  <Button disabled>Disabled</Button>
+  <Button size="sm">Small</Button>
+  <Button size="lg">Large</Button>
+</div>
+
+## Cards
+
+<div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+  <Card>
+    <CardHeader>
+      <CardTitle>Project Snapshot</CardTitle>
+      <CardDescription>Quick overview of a project metric</CardDescription>
+    </CardHeader>
+    <CardContent>
+      <p className="text-2xl font-semibold">98 Lighthouse</p>
+    </CardContent>
+    <CardFooter>
+      <Button variant="outline">View report</Button>
+    </CardFooter>
+  </Card>
+  <Card>
+    <CardHeader>
+      <CardTitle>Newsletter</CardTitle>
+      <CardDescription>Stay in the loop</CardDescription>
+    </CardHeader>
+    <CardContent>
+      <div className="flex gap-2">
+        <Input type="email" placeholder="you@company.com" />
+        <Button>Subscribe</Button>
+      </div>
+    </CardContent>
+  </Card>
+  
+</div>
+
+## Tabs
+
+<Tabs defaultValue="design" className="w-full">
+  <TabsList>
+    <TabsTrigger value="design">Design</TabsTrigger>
+    <TabsTrigger value="dev">Development</TabsTrigger>
+    <TabsTrigger value="ops">Ops</TabsTrigger>
+  </TabsList>
+  <TabsContent value="design">
+    We build clean, accessible interfaces, powered by Tailwind and shadcn/ui.
+  </TabsContent>
+  <TabsContent value="dev">Type-safe, testable code with Next.js, React 19 and modern tooling.</TabsContent>
+  <TabsContent value="ops">Observability, CI/CD and scalable infra from day one.</TabsContent>
+  
+</Tabs>
+
+---
+
+Looking for more? Check out our Pro Templates for production-ready layouts, dashboards, and marketing pages.
+

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -1,0 +1,7 @@
+{
+  "title": "Hrev Dev",
+  "root": true,
+  "pages": [
+    "docs/index"
+  ]
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,6 +10,7 @@
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {
+    "@repo/hrev-ui": "workspace:*",
     "@hookform/resolvers": "^5.0.1",
     "@octokit/rest": "^21.1.1",
     "@radix-ui/react-accordion": "^1.2.11",

--- a/packages/hrev-ui/package.json
+++ b/packages/hrev-ui/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@repo/hrev-ui",
+  "version": "0.0.1",
+  "private": true,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "scripts": {
+    "clean": "git clean -xdf .cache .turbo dist node_modules",
+    "typecheck": "tsc --noEmit --emitDeclarationOnly false"
+  },
+  "dependencies": {
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
+    "clsx": "^2.1.1",
+    "class-variance-authority": "^0.7.1"
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
+    "typescript": "^5.8.3"
+  }
+}

--- a/packages/hrev-ui/src/index.ts
+++ b/packages/hrev-ui/src/index.ts
@@ -1,0 +1,3 @@
+export * from './primitives/button';
+export * from './primitives/card';
+export * from './primitives/tabs';

--- a/packages/hrev-ui/src/primitives/button.tsx
+++ b/packages/hrev-ui/src/primitives/button.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from './utils/cn';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground shadow hover:opacity-90',
+        secondary: 'bg-secondary text-secondary-foreground hover:opacity-90',
+        outline: 'border bg-background hover:bg-muted',
+        ghost: 'hover:bg-muted',
+        destructive: 'bg-destructive text-destructive-foreground hover:opacity-90'
+      },
+      size: {
+        sm: 'h-8 px-3',
+        md: 'h-9 px-4',
+        lg: 'h-10 px-5'
+      }
+    },
+    defaultVariants: { variant: 'default', size: 'md' }
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => (
+    <button ref={ref} className={cn(buttonVariants({ variant, size }), className)} {...props} />
+  )
+);
+Button.displayName = 'Button';
+

--- a/packages/hrev-ui/src/primitives/card.tsx
+++ b/packages/hrev-ui/src/primitives/card.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { cn } from './utils/cn';
+
+export const Card = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('rounded-xl border bg-card text-card-foreground shadow', className)} {...props} />
+);
+
+export const CardHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+);
+
+export const CardTitle = ({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
+  <h3 className={cn('font-semibold leading-none tracking-tight', className)} {...props} />
+);
+
+export const CardDescription = ({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) => (
+  <p className={cn('text-sm text-muted-foreground', className)} {...props} />
+);
+
+export const CardContent = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('p-6 pt-0', className)} {...props} />
+);
+
+export const CardFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex items-center p-6 pt-0', className)} {...props} />
+);
+

--- a/packages/hrev-ui/src/primitives/tabs.tsx
+++ b/packages/hrev-ui/src/primitives/tabs.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+import { cn } from './utils/cn';
+
+export const Tabs = TabsPrimitive.Root;
+
+export const TabsList = ({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.List>) => (
+  <TabsPrimitive.List className={cn('inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground', className)} {...props} />
+);
+
+export const TabsTrigger = ({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) => (
+  <TabsPrimitive.Trigger className={cn('inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow', className)} {...props} />
+);
+
+export const TabsContent = ({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Content>) => (
+  <TabsPrimitive.Content className={cn('mt-2 ring-offset-background focus-visible:outline-none', className)} {...props} />
+);
+

--- a/packages/hrev-ui/src/primitives/utils/cn.ts
+++ b/packages/hrev-ui/src/primitives/utils/cn.ts
@@ -1,0 +1,7 @@
+import { clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: Array<unknown>) {
+  return twMerge(clsx(inputs));
+}
+

--- a/packages/hrev-ui/tsconfig.json
+++ b/packages/hrev-ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -963,6 +963,28 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
 
+  packages/hrev-ui:
+    dependencies:
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+    devDependencies:
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+
   packages/internationalization:
     dependencies:
       '@formatjs/intl-localematcher':
@@ -8766,6 +8788,7 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
 
   node-fetch@2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}


### PR DESCRIPTION
## Description

This pull request establishes the initial online presence for "Hrev Dev," a new web development agency, by transforming the `docs` application. The changes focus on branding the documentation site and showcasing the agency's capabilities.

Key updates include:
- Rebranding the homepage (hero section, footer), navigation title, and site-wide metadata to reflect "Hrev Dev."
- Adding a new "UI Showcase" documentation page to demonstrate core `shadcn/ui` components.
- Introducing a "Pro Templates" documentation page outlining the agency's production-ready template offerings.

These changes lay the groundwork for Hrev Dev's public-facing documentation and service offerings, directly addressing the user's request to utilize the `docs` app for this purpose.

## Related Issues

Closes #<issue_number>

## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests that prove my fix is effective or my feature works.
- [ ] New and existing tests pass locally with my changes.

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes, especially if this is a UI-related PR. -->

## Additional Notes

A comprehensive monorepo structure and strategy for Hrev Dev, including delivery phases and component strategy, was outlined during the development process.

To view the changes locally, please start the docs app:
```bash
cd /workspace/docs
pnpm dev
```

---
<a href="https://cursor.com/background-agent?bcId=bc-ffd9bf57-fb7f-4fa1-8499-32d538bab07c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ffd9bf57-fb7f-4fa1-8499-32d538bab07c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

